### PR TITLE
ext: make ref en/no_en tokens escape-aware

### DIFF
--- a/rosetta.py
+++ b/rosetta.py
@@ -217,11 +217,11 @@ def _leaked_literals(block, seen):
 # Reference
 
 _REF_TOKEN_RE = re.compile(r'\s*(?:'
-    r'//\s*en\s*=\s*(?P<no_en>"[^"]+").*'
+    r'//\s*en\s*=\s*(?P<no_en>"(?:[^"\\]|\\.)+").*'
     r'|(?P<code>//[^\n]*)'
     r'|(?P<open>\{)'
     r'|(?P<close>\},?)'
-    r'|en\s*=\s*(?P<en>"[^"]+"),?'
+    r'|en\s*=\s*(?P<en>"(?:[^"\\]|\\.)+"),?'
     r'|(?P<other>[^\s{}\n][^\n{}]*)'
 r')')
 

--- a/test_rosetta.py
+++ b/test_rosetta.py
@@ -334,6 +334,18 @@ def test_load_ref_single_line(clear_ref):
     assert set(REF_PAIRS) == {"Hello", "World"}
     assert list_pairs('text = "Hello"') == ['{en = "Hello" ru = "Привет"}']
 
+def test_load_ref_escaped_quotes(clear_ref):
+    """en/ru values with escaped inner quotes (as produced by nutstr()) must round-trip."""
+    load_ref(io.StringIO(dedent('''\
+        local pairs = [
+            {
+                en = "He said \\"hi\\" to me"
+                ru = "Dijo \\"hola\\" a mi"
+            }
+        ]
+    ''')))
+    assert 'He said "hi" to me' in REF_PAIRS
+
 def test_load_ref_commas(clear_ref):
     load_ref(io.StringIO(dedent('''\
         local pairs = [


### PR DESCRIPTION
First bug from #2: `_REF_TOKEN_RE`'s `en` and `no_en` groups match values with `"[^"]+"` (rosetta.py:220, rosetta.py:224), which stops at the first quote even when it is escaped. `nutstr()` (rosetta.py:997) emits `\"` for embedded quotes, so any reference file generated by rosetta.py itself that contains an en/ru value with an inner quote could not be consumed back with `-r`: the truncated fragment fails `ast.literal_eval` with `SyntaxError: unterminated string literal`.

Fix: make both groups escape-aware with `"(?:[^"\\]|\\.)+"`, so an escaped character (including `\"`) stays inside the matched token instead of ending it early.

Added `test_load_ref_escaped_quotes`, which feeds `load_ref` a ref block whose en/ru values contain `\"hi\"`/`\"hola\"` and asserts the decoded string (with real quotes) lands in `REF_PAIRS` without raising. Full suite is green before and after (93 passed/1 xfailed baseline on upstream/master, 94 passed/1 xfailed with the new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
