### PR TITLE
ext: match lang value lines atomically in ref tokenizer

### DIFF
--- a/rosetta.py
+++ b/rosetta.py
@@ -222,6 +222,7 @@ _REF_TOKEN_RE = re.compile(r'\s*(?:'
     r'|(?P<open>\{)'
     r'|(?P<close>\},?)'
     r'|en\s*=\s*(?P<en>"[^"]+"),?'
+    r'|(?P<lang>\w+\s*=\s*"(?:[^"\\]|\\.)*",?)'
     r'|(?P<other>[^\s{}\n][^\n{}]*)'
 r')')
 
@@ -297,7 +298,7 @@ def load_ref(ref_file, silent=False):
                 if no_en not in REF_PAIRS:
                     REF_PAIRS[no_en] = '' if silent else m
                 KNOWN_WORDS.update(_iter_keys(no_en))
-            elif tok == 'other':
+            elif tok == 'other' or tok == 'lang':
                 if level > 0:
                     meat = True
 

--- a/test_rosetta.py
+++ b/test_rosetta.py
@@ -329,6 +329,24 @@ def test_load_ref(clear_ref):
     ''')))
     assert set(REF_PAIRS) == {"Hello", "Skipped"}
 
+def test_load_ref_brace_in_value(clear_ref):
+    """A bare { or } inside a target-language value must not desync the block-level counter
+    (BB event text uses {a|b} variant markup heavily). Before the fix this loses the second
+    pair (and corrupts the first) because the stray brace is tokenized as a block delimiter."""
+    load_ref(io.StringIO(dedent('''\
+        local pairs = [
+            {
+                en = "First"
+                ru = "Uno } dos"
+            }
+            {
+                en = "Second"
+                ru = "Dos"
+            }
+        ]
+    ''')))
+    assert set(REF_BLOCKS) == {"First", "Second"}
+
 def test_load_ref_single_line(clear_ref):
     load_ref(io.StringIO('local pairs = [{en = "Hello" ru = "Привет"} {en = "World" ru = "Мир"}]\n'))
     assert set(REF_PAIRS) == {"Hello", "World"}


### PR DESCRIPTION
Second bug from #2: `_REF_TOKEN_RE`'s `other` catch-all (rosetta.py:225, `[^\s{}\n][^\n{}]*`) stops before any brace, so a bare `{` or `}` inside a target-language value (e.g. `ru = "..."`) leaks through as a standalone open/close token instead of staying inside the value. This corrupts `load_ref`'s block-level counter: a value whose brace count does not balance out to exactly the counter's expectation shifts the "phase" of the counter for the rest of the file, so following pairs get silently truncated, merged into the wrong block, or dropped, with no warning. Battle Brothers event text uses `{a|b}` variant markup heavily, so this hits a large fraction of pairs in a real corpus.

Note: a single well-formed `{a|b}` group nets back to the same counter value once both the open and close are seen, so it does not reproduce the desync by itself; the corpus-scale failures come from values whose brace count does not cleanly balance under this token-by-token count (e.g. any leftover/bare `{` or `}`). The included test reproduces this directly with a bare `}` in the first pair's `ru` value.

Fix: add a `lang` token to `_REF_TOKEN_RE` that matches a full `key = "value"` line atomically (mirroring the existing `en` token), placed after `en` and before `other`, so embedded braces stay inside the matched value instead of being tokenized separately. In `load_ref`, `tok == 'lang'` is treated exactly like `tok == 'other'` (sets `meat = True` at `level > 0`), preserving the existing `CODE_RULES`/commented-code-reference semantics unchanged.

Added `test_load_ref_brace_in_value`: two pairs where the first pair's `ru` value contains a bare `}`. Before the fix, the first pair registers with a truncated block and the second pair is lost entirely from `REF_BLOCKS`; after the fix both pairs load with correct, complete block content. Full suite is green before and after (93 passed/1 xfailed baseline on upstream/master, 94 passed/1 xfailed with the new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
