### PR TITLE
ext: treat empty _code as None in _prepare_code

### DIFF
--- a/rosetta.py
+++ b/rosetta.py
@@ -448,7 +448,7 @@ def _format(d):
     return f"{context_comment}    {{\n{_prepare_code(d.get('_code'))}{lines}    }}"
 
 def _prepare_code(code):
-    if code is None:
+    if not code:
         return ''
     lines = [l.replace('\t', ' ') for l in code]
     prefix = min(len(l) - len(l.lstrip(' ')) for l in lines)

--- a/test_rosetta.py
+++ b/test_rosetta.py
@@ -7,7 +7,7 @@ import sys
 import pytest
 from rosetta import extract, load_ref, run_check, check, OPTS, \
     SEEN, REF_PAIRS, REF_RULES, CODE_RULES, REF_BLOCKS, KNOWN_WORDS, _refresh_code, \
-    DUP_CAPTURE_BLOCKS, _dup_captures, BAD_PATTERN_BLOCKS, _bad_pattern_captures
+    DUP_CAPTURE_BLOCKS, _dup_captures, BAD_PATTERN_BLOCKS, _bad_pattern_captures, _prepare_code
 
 OPTS['context'] = True
 OPTS['debug'] = True
@@ -617,6 +617,14 @@ def test_silent_pack(clear_ref, monkeypatch):
 
 
 # _refresh_code tests
+
+def test_prepare_code_none():
+    assert _prepare_code(None) == ''
+
+def test_prepare_code_empty_list():
+    # _refresh_code can call this with an empty _code (a matched ref block refreshing with no
+    # surrounding code); min() over an empty sequence must not raise.
+    assert _prepare_code([]) == ''
 
 def test_refresh_code_no_comments():
     block = """\


### PR DESCRIPTION
Third bug from #2: `_prepare_code` (rosetta.py:450-455) handles `code is None` but not `code == []`: `min(len(l) - len(l.lstrip(' ')) for l in lines)` raises `ValueError: min() iterable argument is empty` when `lines` is empty. This is reachable through `_refresh_code` when a matched ref block refreshes with an empty `_code`. The exception escapes `extract_dir`'s per-file try/except in `extract_file`, so the whole file is skipped with a warning and every pair in it is silently lost; on the vanilla game tree this hit 47 files in one run.

Fix: treat any falsy `code` the same as `None` (`if not code: return ''`), a one-line change.

Added two focused unit tests: `test_prepare_code_none` keeps asserting the existing `_prepare_code(None) == ''` behavior, and `test_prepare_code_empty_list` asserts `_prepare_code([]) == ''` and reproduces the reported `ValueError` before the fix. Full suite is green before and after (93 passed/1 xfailed baseline on upstream/master, 95 passed/1 xfailed with the two new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
