### PR TITLE
hooks: four vanilla conduits that never reach translate()

### DIFF
--- a/rosetta/hooks.nut
+++ b/rosetta/hooks.nut
@@ -89,6 +89,37 @@ mod.queue(">mod_msu", function () {
         }
     })
 
+    // Combat result screen: title matches literal pairs (Victory/Defeat/Retreat),
+    // subtitle matches the rounds patterns
+    mod.hook("scripts/ui/screens/tactical/tactical_combat_result_screen", function (q) {
+        q.onQueryCombatInformation = @(__original) function () {
+            local ret = __original();
+            if (ret != null) {
+                if ("title" in ret) ret.title = _(ret.title);
+                if ("subTitle" in ret) ret.subTitle = _(ret.subTitle);
+            }
+            return ret;
+        }
+    })
+
+    // Loading screen tips
+    mod.hook("scripts/ui/screens/loading/loading_screen", function (q) {
+        q.onQueryData = @(__original) function () {
+            local ret = __original();
+            if (ret != null && "text" in ret) ret.text = _(ret.text);
+            return ret;
+        }
+    })
+
+    // World map party labels ("Peasants (4)"): the engine draws the label but the text
+    // comes from updateStrength(), which concats getName() + " (" + n + ")", so the
+    // suffix stays outside the literal and no pattern is needed. Plain hook, not
+    // hookTree: the only subclass redefining getName (attached_location) delegates
+    // to the base in its live branch, so this point already covers it.
+    mod.hook("scripts/entity/world/world_entity", function (q) {
+        q.getName = simpleGetter;
+    })
+
     // Perks
     mod.hook("scripts/ui/global/data_helper", function (q) {
         q.convertEntityToUIData = @(__original) function (_entity, _activeEntity) {
@@ -159,9 +190,24 @@ mod.queue(">mod_msu", function () {
         q.getName = makeGetter("Name");
         q.getDescription = makeGetter("Description");
     })
+    // Event and contract text is hooked at buildText ENTRY, where %placeholders% are
+    // still raw as extracted pairs store them; at the sq-js border they are already
+    // substituted and no pair would match. One point per class covers event titles,
+    // bodies, dialog options, contract bulletpoints and the active contract panel
+    // title. Plain hook, not hookTree: no vanilla subclass redefines buildText, and
+    // hookTree would wrap every descendant on top of the base, translating twice per
+    // call. Internal strings passing through buildText may log NOT FOUND; harmless.
+    mod.hook("scripts/events/event", function (q) {
+        q.buildText = @(__original) function (_text) {
+            return __original(_(_text));
+        }
+    })
     mod.hook("scripts/contracts/contract", function (q) {
         q.getUITitle = simpleGetter;
         q.getUIButtons = tooltipHook;
+        q.buildText = @(__original) function (_text) {
+            return __original(_(_text));
+        }
     })
 
     // Translate MSU settings: setting labels, page tab names, panel (mod) names, slider labels


### PR DESCRIPTION
Scope: rosetta/hooks.nut only, four new hooks, no behavior change for strings that already translate. This is the "missing paths" follow-up from #2.

All four verified in game in our Spanish pack. Adapt or reimplement freely if you prefer another shape.

**1. Event and contract text, the big one.** Without this hook the body of vanilla events cannot be translated (titles already go through the contract getUITitle hook, bodies go through nothing). The interception point matters and cost us the tracing time: it must be the ENTRY of `buildText`, where `%placeholders%` are still raw, which is how extracted pairs store them; at the sq-js boundary they are already substituted and no pair would ever match. One hook per class covers event titles, bodies, dialog options, contract bulletpoints and the active contract panel title: they all funnel through buildText. Note it is `hook`, not `hookTree`: no vanilla subclass redefines buildText, and hookTree would install the wrapper on every descendant on top of the base, translating twice per call and polluting the NOT FOUND log. Expected noise: some internal strings pass through buildText and log NOT FOUND; harmless.

**2. Combat result screen.** Title matches literal pairs (Victory, Defeat, Retreat), subtitle matches the rounds patterns.

**3. Loading screen tips.**

**4. World map party labels ("Peasants (4)").** The label is drawn by the engine but the text comes from Squirrel (`updateStrength()` composes `getName() + " (" + n + ")"`), the " (4)" suffix stays outside the literal so no pattern is needed, and since updateStrength runs regularly, saved games self-correct. `hook` and not `hookTree` again: the only subclass redefining getName (attached_location) delegates to the base in its live branch, so the base hook already covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
