### PR TITLE
Add :t_raw, a :t that keeps the capture instead of failing the rule

### DIFF
--- a/scripts/!mods_preload/!rosetta.nut
+++ b/scripts/!mods_preload/!rosetta.nut
@@ -317,9 +317,14 @@ Table.extend(def, {
                     ret += p;
                 } else {
                     local t = _matches[p.name];
-                    if (p.flags == "t") {
+                    if (p.flags == "t" || p.flags == "t_raw") {
                         local tt = translate(t);
-                        if (tt == t && _isInteresting(t)) return null;
+                        // :t fails the rule when the piece doesn't translate, so that no
+                        // half-translated string is ever shown. :t_raw keeps the piece as is
+                        // instead, for captures that are safe to show untranslated: ones that
+                        // may arrive pre-translated by another hook, or whose pair translates
+                        // to itself (proper nouns), both indistinguishable from "not found".
+                        if (tt == t && p.flags == "t" && _isInteresting(t)) return null;
                         t = tt;
                     }
                     ret += t;

--- a/test.nut
+++ b/test.nut
@@ -282,6 +282,37 @@ assertTr(
     "Однажды использовал 'Девять жизней', всё равно подох"
 )
 
+// Soft double translation
+setup([
+    {
+        mode = "pattern"
+        en = "<actor:str> was hit in the <part:str>"
+        ru = "<actor> ранен в <part:t>"
+    }
+    {
+        en = "head"
+        ru = "голову"
+    }
+])
+assertTr("Bob was hit in the head", "Bob ранен в голову")
+// A piece with no pair of its own fails the whole rule with :t
+assertTr("Bob was hit in the Mail Shirt", "Bob was hit in the Mail Shirt")
+
+setup([
+    {
+        mode = "pattern"
+        en = "<actor:str> was hit in the <part:str>"
+        ru = "<actor> ранен в <part:t_raw>"
+    }
+    {
+        en = "head"
+        ru = "голову"
+    }
+])
+assertTr("Bob was hit in the head", "Bob ранен в голову")
+// With :t_raw the piece is kept as is and the rest of the rule still applies
+assertTr("Bob was hit in the Mail Shirt", "Bob ранен в Mail Shirt")
+
 // Non-obvious rule keys
 setup({
     mode = "pattern"


### PR DESCRIPTION
Scope: one branch in `useRule` plus a test, no change in behavior for any existing rule. Implements #10; if you would rather fold this into the parameterized `:t` from #6, close it and I will not be offended.

`:t` fails the whole rule when the captured piece doesn't translate, which is the right default. The catch is that "doesn't translate" also covers the piece arriving already translated by another hook, and the piece having a pair that translates to itself: both are indistinguishable from "not found", and both drag an otherwise translatable line back to English. `:t_raw` translates the piece when it can and keeps it as is when it can't, so a rule whose capture may come from two origins renders correctly from both.

Named `t_raw` so it needs nothing from the flag parser; rename as you like.

`sq test.nut` passes with the change and fails without it: on master the new case renders `в head` instead of `в голову`, since an unrecognised flag is ignored.
